### PR TITLE
Fix detecting repo names that don't end in .git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle git repos that don't end in .git when detecting configuration
+
 ## [0.0.3] - 2017-08-16
 
 ### Fixed

--- a/git/git.go
+++ b/git/git.go
@@ -32,7 +32,11 @@ func Open(path string) (*Repository, error) {
 			parts = strings.SplitN(parts[len(parts)-1], "/", -1)
 			owner := parts[len(parts)-2]
 			name := parts[len(parts)-1]
-			name = name[:len(name)-4]
+
+			if strings.HasSuffix(name, ".git") {
+				name = name[:len(name)-4]
+			}
+
 			return &Repository{
 				Owner: owner,
 				Name:  name,


### PR DESCRIPTION
git/ssh owned github repos end in .git, but https ones don't. Handle
both cases.